### PR TITLE
fix: logic to avoid catalog pipeline

### DIFF
--- a/solutions/standard/outputs.tf
+++ b/solutions/standard/outputs.tf
@@ -140,7 +140,7 @@ output "connection_app_type" {
 
 output "application_id" {
   description = "The unique identifier of the mqcloud_application."
-  value       = local.create_application ? module.application[0].id : data.ibm_mqcloud_application.application[0].applications[0].id
+  value       = local.application_id
 }
 
 output "application_create_api_key_uri" {
@@ -165,15 +165,6 @@ output "truststore_root_certificate" {
   description = "The queue manager root CA certificate."
   value       = module.experimental_certificate_root.certificate
   sensitive   = true
-}
-
-########################################################################################################################
-# User
-########################################################################################################################
-
-output "user_email" {
-  description = "name"
-  value       = local.user
 }
 
 ########################################################################################################################

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -120,12 +120,6 @@ variable "user_name" {
   default     = null
 }
 
-variable "existing_user_name" {
-  type        = string
-  description = "The name of an existing user."
-  default     = null
-}
-
 variable "user_email" {
   type        = string
   description = "The email address to given to the new user."

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -78,8 +78,7 @@ func TestRunUpgradeExample(t *testing.T) {
 		},
 	})
 
-	// TODO: Once this test is on main, make this RunTestUpgrade
-	output, err := options.RunTestConsistency()
+	output, err := options.RunTestUpgrade()
 	if !options.UpgradeTestSkipped {
 		assert.Nil(t, err, "This should not have errored")
 		assert.NotNil(t, output, "Expected some output")


### PR DESCRIPTION
### Description

Issue: internal 11734 failure if optional user and/or application are not included

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

- Fix logic for excluding un-required resources

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
