### PR TITLE
Revert "feat: exposes the ability to set the `provider_visibility` in DA"

### DIFF
--- a/cra-config.yaml
+++ b/cra-config.yaml
@@ -6,7 +6,6 @@ CRA_TARGETS:
     PROFILE_ID: "fe96bd4d-9b37-40f2-b39f-a62760e326a3"         # SCC profile ID (currently set to 'IBM Cloud Framework for Financial Services' '1.7.0' profile).
     CRA_ENVIRONMENT_VARIABLES:  # An optional map of environment variables for CRA, where the key is the variable name and value is the value. Useful for providing TF_VARs.
       TF_VAR_existing_mq_capacity_crn: "crn:v1:bluemix:public:mqcloud:us-east:a/abac0df06b644a9cabc6e44f55b3880e:9d9a3c00-2097-4da4-a5e4-78e06514b342::"
-      TF_VAR_provider_visibility: "public"
       TF_VAR_resource_group_name: "test"
       TF_VAR_deployment_name: "deployment"
       TF_VAR_queue_manager_name: "qm"

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -54,23 +54,6 @@
                 "required": true
               },
               {
-                "key": "provider_visibility",
-                "options": [
-                  {
-                    "displayname": "private",
-                    "value": "private"
-                  },
-                  {
-                    "displayname": "public",
-                    "value": "public"
-                  },
-                  {
-                    "displayname": "public-and-private",
-                    "value": "public-and-private"
-                  }
-                ]
-              },
-              {
                 "key": "use_existing_resource_group"
               },
               {

--- a/solutions/standard/provider.tf
+++ b/solutions/standard/provider.tf
@@ -5,5 +5,4 @@
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.region
-  visibility       = var.provider_visibility
 }

--- a/solutions/standard/variables.tf
+++ b/solutions/standard/variables.tf
@@ -7,16 +7,7 @@ variable "ibmcloud_api_key" {
   description = "The IBM Cloud API key to deploy resources."
   sensitive   = true
 }
-variable "provider_visibility" {
-  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
-  type        = string
-  default     = "private"
 
-  validation {
-    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
-    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
-  }
-}
 variable "region" {
   type        = string
   description = "Region to provision new resources created by this solution."

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -75,7 +75,6 @@ func TestRunUpgradeExample(t *testing.T) {
 		"queue_manager_size":         "xsmall",
 		"resource_group_name":        options.Prefix,
 		"application_name":           "app",
-		"provider_visibility":        "public",
 		"user_email":                 "mq-user@exmaple.com",
 		"user_name":                  "mq-user",
 	}
@@ -108,7 +107,6 @@ func TestRunInstanceOnlyExample(t *testing.T) {
 		"queue_manager_name":         "inst",
 		"queue_manager_display_name": "instance-display",
 		"queue_manager_size":         "xsmall",
-		"provider_visibility":        "public",
 		"resource_group_name":        options.Prefix,
 	}
 
@@ -147,7 +145,6 @@ func TestRunStandardSolutionSchematics(t *testing.T) {
 		{Name: "resource_group_name", Value: options.Prefix, DataType: "string"},
 		{Name: "region", Value: "us-east", DataType: "string"},
 		{Name: "deployment_name", Value: "da-mq-instance", DataType: "string"},
-		{Name: "provider_visibility", Value: "public", DataType: "string"},
 		{Name: "queue_manager_name", Value: "da_qm", DataType: "string"},
 		{Name: "queue_manager_display_name", Value: "da-qm-display", DataType: "string"},
 		{Name: "queue_manager_size", Value: "xsmall", DataType: "string"},


### PR DESCRIPTION

### Description


This reverts commit 51797eb741fab45c875787218ee0711bf3f053f9.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

reverts the ability to expose  provider_visibility as mq cloud service doesn't yet support provider_visibility set to private

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
