### PR TITLE
MQ Reserved Capacity provisioning exceeds default timeout

### DIFF
--- a/modules/mq-instance/main.tf
+++ b/modules/mq-instance/main.tf
@@ -23,6 +23,12 @@ resource "ibm_resource_instance" "mqcloud_capacity" {
   }
   service = "mqcloud"
   tags    = var.tags
+
+  timeouts {
+    create = "6h"
+    update = "6h"
+  }
+
 }
 
 resource "ibm_resource_instance" "mqcloud_deployment" {


### PR DESCRIPTION
### Description

This PR addresses a timeout issue encountered during MQ Cloud capacity provisioning [https://github.com/terraform-ibm-modules/terraform-ibm-mq-cloud/issues/151](url)
### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning 

- [] No release
- [X] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Support provisioning of MQ Reserved Capacity instances that take several hours, as documented by IBM Cloud [https://cloud.ibm.com/docs/mqcloud?topic=mqcloud-service_plans](https://github.com/terraform-ibm-modules/terraform-ibm-mq-cloud/issues/url)

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
