### PR TITLE
fix: increase reserved-capacity create and delete timeouts

### DIFF
--- a/modules/mq-instance/main.tf
+++ b/modules/mq-instance/main.tf
@@ -23,6 +23,11 @@ resource "ibm_resource_instance" "mqcloud_capacity" {
   }
   service = "mqcloud"
   tags    = var.tags
+
+  timeouts {
+    create = "8h"
+    delete = "2h"
+  }
 }
 
 resource "ibm_resource_instance" "mqcloud_deployment" {

--- a/modules/mq-instance/variables.tf
+++ b/modules/mq-instance/variables.tf
@@ -27,11 +27,6 @@ variable "existing_mq_capacity_crn" {
   type        = string
   description = "The CRN of an existing capacity service instance, if not specifed, a new capacity plan will be created."
   default     = null
-
-  validation {
-    condition     = (var.existing_mq_capacity_crn != null && var.subscription_id == null) || (var.existing_mq_capacity_crn == null && var.subscription_id != null)
-    error_message = "Exactly one of 'existing_mq_capacity_crn' or 'subscription_id' is required."
-  }
 }
 
 variable "subscription_id" {


### PR DESCRIPTION
### Description

Address issues #150 and #151.

When provision a reserved-capacity or reserved-capacity-subscription service instance the timeout is 8 hours.
Reduce the validation to permit reserved-capacity service instance to be created by passing neither subscription_id or existing capacity instance CRN. reserved-capacity service instance are not available in most regions.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Increase the timeout waiting to create single tenant capacity instances.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
